### PR TITLE
Use peer dependencies for handlebars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - 0.10
+before_install:
+  - "npm install -g npm@2.3.0"
 after_script:
   - npm run coveralls

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var glob = require('globby'),
+	handlebars = require('handlebars'),
 	path = require('path'),
 	pathSepPattern = /[ \/.-]+/g; // matches spaces, forward slashes, dots, and hyphens
 
@@ -106,14 +107,13 @@ function registerModule(method, cwd, file) {
  * Effortless wiring of Handlebars helpers and partials.
  *
  * @type {Function}
- * @param {Object} handlebars Handlebars instance.
  * @param {Object} options Plugin options.
  * @param {String} options.cwd Current working directory. Defaults to `process.cwd()`.
  * @param {String|Array.<String>} options.helpers One or more glob strings matching helpers.
  * @param {String|Array.<String>} options.partials One or more glob strings matching partials.
  * @return {Object} Handlebars instance.
  */
-function registrar(handlebars, options) {
+function registrar(options) {
 	options = options || {};
 
 	var register,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "test": "gulp test"
   },
+  "engineStrict": true,
   "engines": {
     "npm": ">2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "test": "gulp test"
   },
-  "engineStrict": true,
-  "engines": {
-    "npm": ">2.2.0"
-  },
   "dependencies": {
     "globby": "^1.1.0"
   },
@@ -42,7 +38,9 @@
     "gulp-mocha": "^2.0.0",
     "jshint-stylish": "^1.0.0"
   },
+  "engineStrict": true,
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 0.10",
+    "npm": ">2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "dependencies": {
     "globby": "^1.1.0"
   },
+  "peerDependencies": {
+    "handlebars": ">1.1.0"
+  },
   "devDependencies": {
     "coveralls": "^2.11.2",
     "expect.js": "^0.3.1",
@@ -33,7 +36,6 @@
     "gulp-jscs": "^1.4.0",
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
-    "handlebars": "^2.0.0",
     "jshint-stylish": "^1.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "test": "gulp test"
   },
+  "engines": {
+    "npm": ">2.2.0"
+  },
   "dependencies": {
     "globby": "^1.1.0"
   },

--- a/test/handlebars-registrar.spec.js
+++ b/test/handlebars-registrar.spec.js
@@ -1,20 +1,16 @@
 'use strict';
 
 var handlebarsRegistrar = require('../index'),
-	handlebars = require('handlebars'),
+	hb = require('handlebars'),
 	expect = require('expect.js');
 
 describe('handlebars-registrar e2e', function () {
 	it('should use default options', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb);
+		handlebarsRegistrar();
 	});
 
 	it('should register simple helpers', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb, {
+		handlebarsRegistrar({
 			helpers: __dirname + '/fixtures/helpers/function/**/*.js'
 		});
 
@@ -26,9 +22,7 @@ describe('handlebars-registrar e2e', function () {
 	});
 
 	it('should register an object of helpers', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb, {
+		handlebarsRegistrar({
 			helpers: __dirname + '/fixtures/helpers/object/*.js'
 		});
 
@@ -39,9 +33,7 @@ describe('handlebars-registrar e2e', function () {
 	});
 
 	it('should defer registration of helpers', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb, {
+		handlebarsRegistrar({
 			helpers: __dirname + '/fixtures/helpers/deferred/*.js'
 		});
 
@@ -52,9 +44,7 @@ describe('handlebars-registrar e2e', function () {
 	});
 
 	it('should register raw partials', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb, {
+		handlebarsRegistrar({
 			partials: __dirname + '/fixtures/partials/raw/**/*.hbs'
 		});
 
@@ -65,9 +55,7 @@ describe('handlebars-registrar e2e', function () {
 	});
 
 	it('should register an object of partials', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb, {
+		handlebarsRegistrar({
 			partials: __dirname + '/fixtures/partials/object/*.js'
 		});
 
@@ -78,9 +66,7 @@ describe('handlebars-registrar e2e', function () {
 	});
 
 	it('should defer registration of partials', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb, {
+		handlebarsRegistrar({
 			partials: __dirname + '/fixtures/partials/deferred/*.js'
 		});
 
@@ -91,9 +77,7 @@ describe('handlebars-registrar e2e', function () {
 	});
 
 	it('should allow setting the cwd', function () {
-		var hb = handlebars.create();
-
-		handlebarsRegistrar(hb, {
+		handlebarsRegistrar({
 			cwd: __dirname,
 			helpers: 'fixtures/helpers/function/**/*.js',
 			partials: 'fixtures/partials/raw/**/*.hbs'


### PR DESCRIPTION
### Rationale

Normally in any given project, there's only one version of handlebars, instead of relying on any particular version inside the `handlebars-registrar` module, use `peerDependencies` object in the `package.json`. This allow the user of the module to use the version that he sees fit, if no version is given it will use the most recent one.

In order to use `registerPartial` and `registerHelper` the minimum version of handlebars that complies with the signature of those methods is `v1.1.0`.

Finally this change will break your api, because it no longer needs the handlebars object.
#### Usage

``` js
var registrar = require('handlebars-registrar');

registrar({
    helpers: './helpers/**/*.js',
    partials: [
        './partials/**/*.{hbs,js}',
        './layouts/**/*.hbs'
    ]
});
```
